### PR TITLE
Avoid naming conflicts

### DIFF
--- a/src/disasm/disasm.h
+++ b/src/disasm/disasm.h
@@ -90,7 +90,7 @@ enum instructions
 {
     none, add, push, pop, or, adc, sbb, and, es, daa,
     sub, cs, das, xor, ss, aaa, cmp, ds, aas, inc, dec, jump, test, xchg,
-    mov, lea, nop, cbw, cwd, call, wait, pushf, popf, sahf, lahf, movs,
+    mov, lea, nop, cbw, cwd, call, __wait, pushf, popf, sahf, lahf, movs,
     cmps, stos, lods, scas, ret, les, lds, retf, intr, into, iret, rol,
     ror, rcl, rcr, shl, shr, sar, aam, aad, xlat, esc, loopne, loope, loop,
     jcxz, in, out, jmp, lock, repz, repnz, hlt, cmc, not, neg, mul, imul,
@@ -269,7 +269,7 @@ static struct Disasm
 { cbw },                        /* 0x98 */
 { cwd },                        /* 0x99 */
 { call,decode_far },            /* 0x9a */
-{ wait },                       /* 0x9b */
+{ __wait },                       /* 0x9b */
 { pushf },                      /* 0x9c */
 { popf },                       /* 0x9d */
 { sahf },                       /* 0x9e */


### PR DESCRIPTION
On macOS, clang raises the following build errors:
```
  src/disasm/disasm.h:93:36: error: redefinition of 'wait'
      mov, lea, nop, cbw, cwd, call, wait, pushf, popf, sahf, lahf, movs,
                                   ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/wait.h:248:9: note: previous definition is here
  pid_t   wait(int *) __DARWIN_ALIAS_C(wait);
          ^
  In file included from src/disasm/debugger.c:25:
  src/disasm/disasm.h:272:3: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'pid_t (int *)' (aka 'int (int *)') [-Werror,-Wint-conversion]
  { wait },                       /* 0x9b */
    ^~~~
  src/disasm/disasm.h:272:3: error: initializer element is not a compile-time constant
  { wait },                       /* 0x9b */
    ^~~~
  3 errors generated.
```

To avoid naming conflicts, the identifier 'wait' is renamed.